### PR TITLE
fix: use setup-go and put govulncheck on PATH

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -59,28 +59,36 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ inputs.go-version }}
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run govulncheck
         id: scan
         run: |
+          set -euo pipefail
           cd "${{ inputs.working-directory }}"
 
-          ARGS=""
-          [ "${{ inputs.mode }}" != "source" ] && ARGS="$ARGS -mode=${{ inputs.mode }}"
-          [ -n "${{ inputs.tags }}" ] && ARGS="$ARGS -tags=${{ inputs.tags }}"
-          [ "${{ inputs.include-tests }}" = "true" ] && ARGS="$ARGS -test"
-          [ "${{ inputs.json-output }}" = "true" ] && ARGS="$ARGS -json"
-          [ "${{ inputs.imports-only }}" = "true" ] && ARGS="$ARGS -imports-only"
-          [ "${{ inputs.symbolize }}" = "true" ] && ARGS="$ARGS -symbolize"
+          if ! command -v govulncheck >/dev/null 2>&1; then
+            echo "::error::govulncheck binary not found on PATH after install"
+            exit 1
+          fi
 
-          echo "Running govulncheck with args: $ARGS"
-          if ! govulncheck $ARGS ./...; then
+          ARGS=()
+          [ "${{ inputs.mode }}" != "source" ] && ARGS+=("-mode=${{ inputs.mode }}")
+          [ -n "${{ inputs.tags }}" ] && ARGS+=("-tags=${{ inputs.tags }}")
+          [ "${{ inputs.include-tests }}" = "true" ] && ARGS+=("-test")
+          [ "${{ inputs.json-output }}" = "true" ] && ARGS+=("-json")
+          [ "${{ inputs.imports-only }}" = "true" ] && ARGS+=("-imports-only")
+          [ "${{ inputs.symbolize }}" = "true" ] && ARGS+=("-symbolize")
+
+          echo "Running govulncheck with args: ${ARGS[*]:-<none>}"
+          if ! govulncheck "${ARGS[@]}" ./...; then
             echo "::error::govulncheck found vulnerabilities"
             exit 1
           fi
@@ -89,5 +97,5 @@ jobs:
       - name: Check scan status
         if: steps.scan.outcome == 'failure'
         run: |
-          echo "::error::Vulnerabilities found in the codebase. Please review the scan results above."
+          echo "::error::govulncheck found vulnerabilities. Please review the scan results above."
           exit 1


### PR DESCRIPTION
## Summary
- Replace mistaken `actions/setup-node` with `actions/setup-go`
- Append `$(go env GOPATH)/bin` to `GITHUB_PATH` after install
- Fail clearly if the binary is missing instead of claiming vulnerabilities

## Test plan
- [ ] CI on this action passes
- [ ] Caller (e.g. platformfuzz/k8s-inspector) govulncheck job runs the binary